### PR TITLE
Restart script.

### DIFF
--- a/scripts/restart-on-high-load.sh
+++ b/scripts/restart-on-high-load.sh
@@ -1,0 +1,7 @@
+CPU_USAGE=$(uptime | cut -d"," -f5 | cut -d":" -f2 | cut -d" " -f2 | sed -e "s/\.//g")
+CPU_USAGE_THRESHOLD=200
+
+if [ $CPU_USAGE -gt $CPU_USAGE_THRESHOLD ] ; then
+  systemctl restart linguine-node
+  systemctl restart linguine-python
+fi


### PR DESCRIPTION
This script is checked in root's crontab.  Basically, the script just checks if the CPUs have been under 100% use for 15 minutes.  If so, it will restart both python and node.  The current server has 2 CPUs, so a load average of 2.00 (represented as 200 in the code) would mean that they are under 100% use.  If this app eventually got more CPUs, we'd have to up this number.
